### PR TITLE
Updated source eframe template to v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,12 +161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,12 +293,6 @@ name = "atomic-waker"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
-
-[[package]]
-name = "atomic_refcell"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
 
 [[package]]
 name = "atspi"
@@ -697,9 +685,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e479a7fa3f23d4e794f8b2f8b3568dd4e47886ad1b12c9c095e141cb591eb63"
+checksum = "cfdf4e52dbbb615cfd30cf5a5265335c217b5fd8d669593cea74a517d9c605af"
 dependencies = [
  "bytemuck",
  "serde",
@@ -707,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4596583a2c680c55b6feaa748f74890c4f9cb9c7cb69d6117110444cb65b2f"
+checksum = "26d9efede6c8905d3fc51a5ec9a506d4da4011bbcae0253d0304580fe40af3f5"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -724,10 +712,12 @@ dependencies = [
  "js-sys",
  "log",
  "objc",
+ "parking_lot",
  "percent-encoding",
  "raw-window-handle",
  "ron",
  "serde",
+ "static_assertions",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -750,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aef8ec3ae1b772f340170c65bf27d5b8c28f543a0116c844d2ac08d01123e7"
+checksum = "8bd69fed5fcf4fbb8225b24e80ea6193b61e17a625db105ef0c4d71dde6eb8b7"
 dependencies = [
  "accesskit",
  "ahash",
@@ -765,27 +755,27 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a49155fd4a0a4fb21224407a91de0030847972ef90fc64edb63621caea61cb2"
+checksum = "c15479a96d9fadccf5dac690bdc6373b97b8e1c0dd28367058f25a5298da0195"
 dependencies = [
  "accesskit_winit",
  "arboard",
  "egui",
- "instant",
  "log",
  "raw-window-handle",
  "serde",
  "smithay-clipboard",
+ "web-time",
  "webbrowser",
  "winit",
 ]
 
 [[package]]
 name = "egui_glow"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8c2752cdf1b0ef5fcda59a898cacabad974d4f5880e92a420b2c917022da64"
+checksum = "ce6726c08798822280038bbad2e32f4fc3cbed800cd51c6e34e99cd2d60cc1bc"
 dependencies = [
  "bytemuck",
  "egui",
@@ -798,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3857d743a6e0741cdd60b622a74c7a36ea75f5f8f11b793b41d905d2c9721a4b"
+checksum = "1ef2b29de53074e575c18b694167ccbe6e5191f7b25fe65175a0d905a32eeec0"
 dependencies = [
  "bytemuck",
  "serde",
@@ -853,13 +843,12 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09333964d4d57f40a85338ba3ca5ed4716070ab184dcfed966b35491c5c64f3b"
+checksum = "58067b840d009143934d91d8dcb8ded054d8301d7c11a517ace0a99bb1e1595e"
 dependencies = [
  "ab_glyph",
  "ahash",
- "atomic_refcell",
  "bytemuck",
  "ecolor",
  "emath",
@@ -1870,19 +1859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "sctk-adwaita"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
-dependencies = [
- "ab_glyph",
- "log",
- "memmap2",
- "smithay-client-toolkit",
- "tiny-skia",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,12 +2001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
-name = "strict-num"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df65f20698aeed245efdde3628a6b559ea1239bbb871af1b6e3b58c413b2bd1"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,31 +2062,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.16",
-]
-
-[[package]]
-name = "tiny-skia"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "png",
- "tiny-skia-path",
-]
-
-[[package]]
-name = "tiny-skia-path"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c"
-dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
 ]
 
 [[package]]
@@ -2273,9 +2218,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2283,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -2310,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2320,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2333,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wayland-client"
@@ -2429,6 +2374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19353897b48e2c4d849a2d73cb0aeb16dc2be4e00c565abfc11eb65a806e47de"
+dependencies = [
+ "js-sys",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2677,7 +2633,6 @@ dependencies = [
  "percent-encoding",
  "raw-window-handle",
  "redox_syscall 0.3.5",
- "sctk-adwaita",
  "smithay-client-toolkit",
  "wasm-bindgen",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.71"
 
 
 [dependencies]
-egui = "0.22.0"
-eframe = { version = "0.22.0", default-features = false, features = [
+egui = "0.23.0"
+eframe = { version = "0.23.0", default-features = false, features = [
     "accesskit",     # Make egui comptaible with screen readers. NOTE: adds a lot of dependencies.
     "default_fonts", # Embed the default egui fonts.
     "glow",          # Use the glow rendering backend. Alternative: "wgpu".

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,8 +5,7 @@ pub struct TemplateApp {
     // Example stuff:
     label: String,
 
-    // this how you opt-out of serialization of a member
-    #[serde(skip)]
+    #[serde(skip)] // This how you opt-out of serialization of a field
     value: f32,
 }
 
@@ -43,74 +42,67 @@ impl eframe::App for TemplateApp {
     }
 
     /// Called each time the UI needs repainting, which may be many times per second.
-    /// Put your widgets into a `SidePanel`, `TopPanel`, `CentralPanel`, `Window` or `Area`.
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        let Self { label, value } = self;
-
-        // Examples of how to create different panels and windows.
-        // Pick whichever suits you.
-        // Tip: a good default choice is to just keep the `CentralPanel`.
+        // Put your widgets into a `SidePanel`, `TopPanel`, `CentralPanel`, `Window` or `Area`.
         // For inspiration and more examples, go to https://emilk.github.io/egui
 
-        #[cfg(not(target_arch = "wasm32"))] // no File->Quit on web pages!
         egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
             // The top panel is often a good place for a menu bar:
+
             egui::menu::bar(ui, |ui| {
-                ui.menu_button("File", |ui| {
-                    if ui.button("Quit").clicked() {
-                        _frame.close();
-                    }
-                });
-            });
-        });
+                #[cfg(not(target_arch = "wasm32"))] // no File->Quit on web pages!
+                {
+                    ui.menu_button("File", |ui| {
+                        if ui.button("Quit").clicked() {
+                            _frame.close();
+                        }
+                    });
+                    ui.add_space(16.0);
+                }
 
-        egui::SidePanel::left("side_panel").show(ctx, |ui| {
-            ui.heading("Side Panel");
-
-            ui.horizontal(|ui| {
-                ui.label("Write something: ");
-                ui.text_edit_singleline(label);
-            });
-
-            ui.add(egui::Slider::new(value, 0.0..=10.0).text("value"));
-            if ui.button("Increment").clicked() {
-                *value += 1.0;
-            }
-
-            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 0.0;
-                    ui.label("powered by ");
-                    ui.hyperlink_to("egui", "https://github.com/emilk/egui");
-                    ui.label(" and ");
-                    ui.hyperlink_to(
-                        "eframe",
-                        "https://github.com/emilk/egui/tree/master/crates/eframe",
-                    );
-                    ui.label(".");
-                });
+                egui::widgets::global_dark_light_mode_buttons(ui);
             });
         });
 
         egui::CentralPanel::default().show(ctx, |ui| {
             // The central panel the region left after adding TopPanel's and SidePanel's
-
             ui.heading("eframe template");
-            ui.hyperlink("https://github.com/emilk/eframe_template");
+
+            ui.horizontal(|ui| {
+                ui.label("Write something: ");
+                ui.text_edit_singleline(&mut self.label);
+            });
+
+            ui.add(egui::Slider::new(&mut self.value, 0.0..=10.0).text("value"));
+            if ui.button("Increment").clicked() {
+                self.value += 1.0;
+            }
+
+            ui.separator();
+
             ui.add(egui::github_link_file!(
                 "https://github.com/emilk/eframe_template/blob/master/",
                 "Source code."
             ));
-            egui::warn_if_debug_build(ui);
-        });
 
-        if false {
-            egui::Window::new("Window").show(ctx, |ui| {
-                ui.label("Windows can be moved by dragging them.");
-                ui.label("They are automatically sized based on contents.");
-                ui.label("You can turn on resizing and scrolling if you like.");
-                ui.label("You would normally choose either panels OR windows.");
+            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                powered_by_egui_and_eframe(ui);
+                egui::warn_if_debug_build(ui);
             });
-        }
+        });
     }
+}
+
+fn powered_by_egui_and_eframe(ui: &mut egui::Ui) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        ui.label("Powered by ");
+        ui.hyperlink_to("egui", "https://github.com/emilk/egui");
+        ui.label(" and ");
+        ui.hyperlink_to(
+            "eframe",
+            "https://github.com/emilk/egui/tree/master/crates/eframe",
+        );
+        ui.label(".");
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,11 @@
 fn main() -> eframe::Result<()> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
 
-    let native_options = eframe::NativeOptions::default();
+    let native_options = eframe::NativeOptions {
+        initial_window_size: Some([400.0, 300.0].into()),
+        min_window_size: Some([300.0, 220.0].into()),
+        ..Default::default()
+    };
     eframe::run_native(
         "eframe template",
         native_options,


### PR DESCRIPTION
[To update source template]
Squashed commit of the following:

commit 979870a86be92f805b989d50d46e43789bf7daf1
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Sep 28 08:55:19 2023 +0200

    Update to egui 0.23 and improve the app

commit 2080463158c67897139afcfd193f8de6b8456535
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon Sep 4 09:36:55 2023 +0200

    Update to rust 1.71 (#106)

commit 188732309bdac15b5ba50f2b6b4b610f4164fd87
Author: Elliott Slaughter <elliottslaughter@gmail.com>
Date:   Tue Aug 8 12:48:00 2023 -0700

    Remove filehash setting from Trunk.toml (#102)

    By default, Trunk uses infinite caching. Without a file hash, this makes it quite easy for users to see stale copies of an application. The file hash (Trunk's default setting) ensures that users always load the exact hashed version that corresponds to what is currently deployed.

commit 2b6b3135d079dc70c40cf25e1c4245157bd694d9
Author: Norbert Sebők <seboknorbi@gmail.com>
Date:   Tue Aug 8 21:46:52 2023 +0200

    Added missing `rustup target add` for "web locally" (#101)

    * Added missing `rustup target add` for web deploy

    * Added missing `rustup target add` for "web locally"

commit 43a7f7627a647a86cfb4e9a7c8f121dd940b5742
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue May 23 21:06:40 2023 +0200

    Switch to env_logger

commit 5ff1713daede99d1c4fa63c9eb2d9e966a8e841a
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue May 23 20:38:37 2023 +0200

    Update to egui 0.22

commit 4f613f5d6266f0f0888544df4555e6bc77a5d079
Merge: 29d0f92 ed0d4d1
Author: Andreas Reich <r_andreas2@web.de>
Date:   Fri Feb 10 09:49:54 2023 +0100

    Merge pull request #94 from coderedart/build_flags_fix

    fixes #93 . use target, instead of build section for web unstable apis

commit 29d0f92ad743cd2f9ed263436ac19d43399c571a
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Wed Feb 8 20:36:49 2023 +0100

    Update eframe and egui to 0.21.0

commit ed0d4d1d2e2dcb545af66f3433c157e5f9ca14c1
Author: Red Artist <redartofcode@gmail.com>
Date:   Thu Feb 2 08:58:16 2023 +0530

    use target, instead of build section for web unstable apis

commit 4d8287894c879fccbbff6afce438520580838d3a
Merge: 5766c72 65d9939
Author: Andreas Reich <r_andreas2@web.de>
Date:   Sat Dec 17 12:35:00 2022 +0100

    Merge pull request #89 from James2022-rgb/feature/fix-typo

    Fix typo in app.rs

commit 65d9939d19590cba2c559532f14a3237a803f88f
Author: James0124 <gladiatorrules22@gmail.com>
Date:   Sat Dec 17 19:31:34 2022 +0900

    Fix typo in app.rs

commit 5766c72ce0cbe0f120c6049580040a966b254111
Merge: 0d7b06b a3f3a92
Author: Andreas Reich <r_andreas2@web.de>
Date:   Sun Dec 11 10:14:50 2022 +0100

    Merge pull request #86 from elliottslaughter/patch-1

    Fix spelling of default-features in Cargo.toml

commit a3f3a925cdf7b316a75d23c78f5cd2d126f07c9d
Author: Elliott Slaughter <elliottslaughter@gmail.com>
Date:   Sat Dec 10 11:59:50 2022 -0800

    Fix spelling of default-features in Cargo.toml

commit 0d7b06b16088ce16b3b027a97541a69ea40a972c
Author: Andreas Reich <r_andreas2@web.de>
Date:   Thu Dec 8 15:44:35 2022 +0100

    Update to egui/eframe 0.20.0 (#83)

    * Fix issues with eframe::start_web becoming async

    * Explain the different eframe feature flags

    * explain the dummy main function

    * Update to rust 1.65

    * Use `wasm_bindgen_futures::spawn_local`

    * opt-in to all eframe dependencies

    * Update egui/eframe to 0.20.0

    Co-authored-by: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>

commit 32f491334ee29c64a3583ccb92388455bc28b6e6
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon Nov 7 23:25:27 2022 +0100

    Optimize dependencies in debug builds

commit 88b788d6a59883e8833a02244b29218ff641657c
Author: Red Artist <redartofcode@gmail.com>
Date:   Mon Nov 7 21:03:06 2022 +0530

    add rust flags in cargo config for web-sys unstable (#81)

commit a02f5f6d06d866304a769a3135b5ff872b5cc776
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon Nov 7 13:57:32 2022 +0100

    Update instructions to enable web_sys_unstable_apis when building

commit 4367426862bbdecd4102762d97c296bb3f8ebef1
Author: Markus Krause <Krause.Markus@gmx.com>
Date:   Mon Oct 24 08:34:25 2022 +0200

    Fix typo in README (#76)

    it ain't much, but it's honest work ;)

commit 692d9865cdce5d8e00d83f60d7cf003aaf4022e7
Author: xosxos <44613540+xosxos@users.noreply.github.com>
Date:   Fri Sep 16 00:07:14 2022 +0300

    Update README.md to compile on Fedora (#74)

commit 3fb74d7d2bba702833c96784598b51311bc86cba
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon Aug 22 09:35:27 2022 +0200

    Update another eframe link

commit f50f3e60b2fbdd6b2d8b12cfc1d73209da7c74df
Author: Liam Bigelow <40188355+bglw@users.noreply.github.com>
Date:   Mon Aug 22 19:34:21 2022 +1200

    Update links to eframe in the egui monorepo (#70)

commit 88e0b19c50bd444b5f19a90c931c96e376439404
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sat Aug 20 17:08:00 2022 +0200

    Update to egui/eframe 0.19.0

commit 08b025b4e4f79b1bbaa7af23727961d0bf9a0be8
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Fri Aug 19 17:41:46 2022 +0200

    Spelling fixes after https://github.com/emilk/eframe_template/pull/69

commit d12c19da37de943d06703bec09613cf7121a70f9
Author: Red Artist <redartofcode@gmail.com>
Date:   Fri Aug 19 21:03:23 2022 +0530

    Use Trunk to build and deploy the web app (#69)

commit e1e4fb811382528c18d5b90bcee69c1f1bea3771
Author: Tim Hopp <57064437+hoptimized@users.noreply.github.com>
Date:   Tue Aug 2 17:23:59 2022 +0200

    Make paths in index.html relative (#68)

    Closes #67

    Remove the top-level path (`/`) from all source links in index.html so that
    the template takes relative paths can work when hosted under a path,
    e.g. `https://emilk.github.io/eframe_template/`

commit be77c2a718678ceac562e49b74b6484edde2208d
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Aug 2 09:56:33 2022 +0200

    Run wasm-bindgen on CI (#66)

    * run wasm-bindgen on CI

    * Use pinned version of wasm-bindgen-cli

    * cargo update

commit 3649d3453dc2994d2cf434263e90724c20062db4
Author: Alex Kazik <alex@kazik.de>
Date:   Thu Jul 7 19:09:31 2022 +0200

    Disable offline caching during development

    This makes development easier as always the latest version is used.

commit 1ea0172f9453c782a8efdbebf1f540a156e9d2bd
Author: Alex Kazik <alex@kazik.de>
Date:   Thu Jul 7 19:02:12 2022 +0200

    Change `build_web.sh` option from `--fast` to `--optimize`

    Co-authored-by: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>

commit c5a56f2082ab8527cdb31db2963d9ce188746caf
Author: Alex Kazik <alex@kazik.de>
Date:   Thu Jul 7 18:59:20 2022 +0200

    Update readme: add instruction to install jq

commit 843f250c9b42959f2ac8bb5250bf0f5aa1d9075c
Author: Alex Kazik <alex@kazik.de>
Date:   Thu Jul 7 18:56:16 2022 +0200

    Make it easier to adapt some settings for the web

commit eed822cf46ae784ea8c2b26a1b28345dd8f950b5
Author: Alex Kazik <alex@kazik.de>
Date:   Thu Jul 7 18:55:29 2022 +0200

    Remove duplicate cargo install

    It's already executed in setup_web.sh.

commit 9ff285409d4b73fdc575eff517ceb7059664dfe4
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sat Apr 30 20:51:28 2022 +0200

    Update rust-version to 1.60

commit d44c4f5311f42ed41a74f358b4f686dc88a5530f
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sat Apr 30 20:49:45 2022 +0200

    Update to egui 0.18.0 (#58)

    * WIP: Update to egui 0.18.0 (still unreleased)

    * Update to eframe/egui 0.18.0

    * cargo update

commit 341c9b06ff91651690b5d6f512839f8c102573ff
Author: Thomas Ramirez <Jimskapt@users.noreply.github.com>
Date:   Sat Apr 30 11:01:23 2022 +0200

    🐛 Fix path containing spaces in `build_web.bat` (#57)

    Closes emilk/eframe_template#56

commit c6b97756e94c4e3595bbb7ac60fd4d993e39d325
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Apr 7 17:36:37 2022 +0200

    Use proper shebang for all bash scripts: #!/usr/bin/env bash

commit ed07d0a1ada447664c2f7b3941f6cac67061b317
Author: Thomas Ramirez <Jimskapt@users.noreply.github.com>
Date:   Sun Apr 3 21:09:13 2022 +0200

    🚨 Fix compilation warning about bin name conflict. (#50)

    * 🚨 Fix compilation warning about lib/bin name conflict.

    * 📝 Update `README.md` instructions for binary name.

commit bdc11d80074d30d52341fa1fa0fc2705c47418e0
Author: MrTanoshii <47116127+MrTanoshii@users.noreply.github.com>
Date:   Tue Mar 29 02:33:52 2022 +0400

    docs: Add template rename instruction in `main.rs` & removed extra space (#54)

commit 86fe7b7b87e3a3868ce2648a3f2a63b6a044133f
Author: NHodgesVFX <NhodgesVFX@gmail.com>
Date:   Tue Mar 22 03:31:14 2022 -0400

    Hide console window in release builds on Windows (#53)

commit 5729bc025bf557adb07d1b668267b86fe33b3a15
Author: NHodgesVFX <nate897e@gmail.com>
Date:   Sat Mar 19 08:17:18 2022 -0400

    Improve PWA Support (#52)

commit a259f2558c28048e7e4b35a7ceeeee610b6cd841
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Feb 22 19:40:33 2022 +0100

    Update to egui 0.17.0

commit 8f5247e83199a1de9cc9b6d6a864ea8f4dfb12ce
Author: austenadler <s5jitqluypqitf23ayssjtggxmafl4ti@fastmail.com>
Date:   Wed Feb 9 14:46:49 2022 +0000

    Use shell best practices in build_web.sh (#49)

    * Quote all shell variables

    * Use [[ ]]/$() over [ ]/``

    Co-authored-by: Austen Adler <agadler@austenadler.com>

commit e5e87231a0d29e9905d472574b31246656f76b37
Author: Thomas Ramirez <Jimskapt@users.noreply.github.com>
Date:   Mon Feb 7 10:38:20 2022 +0100

    🔨 Translate `*.sh` into `*.bat` (#46)

    ... for Microsoft Windows users

commit f1d272b37dae2d27c2e80cdf308b556062425e49
Author: Thomas Ramirez <Jimskapt@users.noreply.github.com>
Date:   Mon Feb 7 10:37:15 2022 +0100

    Add `sw.js` name change instructions in `README.md` (#47)

commit 44aec52217ffaf1098fcf929449a0dbd374f257a
Author: Ashwin Vinod <ashwinvinodsa@gmail.com>
Date:   Mon Jan 31 19:31:29 2022 +0530

    Fix typo: binaryena -> binaryen (#45)

    changed `binaryena` to `binaryen`

commit 7e970d95e6002b493d91117bd912adf7a5c37f09
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Wed Jan 19 13:22:51 2022 +0100

    Improve instructions for how to rename template project

commit abf13297bcb785204769d064f1cc5bde19818b50
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Dec 30 21:51:40 2021 +0100

    Add missing fedora packet libxcb-devel

    See https://github.com/emilk/egui/pull/1018

commit 797a3f5afae8da6bcabdc5fc86d865abe4fb3afd
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Wed Dec 29 12:28:52 2021 +0100

    Update to egui/eframe 0.16.0

commit 71211e01104c91da883b75ff88e5c5a839c44d89
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Dec 28 21:29:52 2021 +0100

    setup_web.sh: don't force-install wasm-bindgen-cli

commit d8b27637697c77d9631f683069be0a7d757aa1c0
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Dec 28 21:29:36 2021 +0100

    Explain "docs" folder

commit f5c35169a76ed09f0da9489dc27063f527219f31
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Dec 28 21:29:26 2021 +0100

    Add favicon

commit 59a5eb297b6838f4133075642bbec67cf596ea22
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Dec 28 21:29:15 2021 +0100

    Add loading animation to web app

commit 4b9a355add87bda49a4e63753922de93562225b1
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Dec 28 21:27:26 2021 +0100

    Add links to egui demo app, egui docs and tutorial video in README.md

commit df6f9610d12a24bc7f445f97f61880fb145fab80
Author: Mingun <Alexander_Sergey@mail.ru>
Date:   Wed Dec 29 00:48:11 2021 +0500

    Correctly determine the target directory when project inside workspace (#28)

commit 3bef7afa69d88f02a949a27dcb4a214e718c95ba
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sun Oct 24 16:23:10 2021 +0200

    Update eframe and egui to 0.15.0

commit 77626b9ec33e0351ce741c883393195b601f477a
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon Oct 18 20:17:48 2021 +0200

    Rename to eframe_template

    Previously known as egui_template

commit 100b9eebdd20e6b300c77afd2541afd71f0dcef9
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Sep 14 12:34:59 2021 +0200

    Remove #[cfg(feature = "persistence")] from around setup

    Related: https://github.com/emilk/egui/discussions/718#discussioncomment-1322991

commit f55dfd2d1fe06c5b421414e039c1f07eed61fa33
Merge: ba5e6d7 144f0c6
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Sep 2 21:24:42 2021 +0200

    Merge pull request #24 from DanInSpace104/patch-1

    Document dependencies for Fedora Rawhide

commit 144f0c62b54b5b58157ebb08fdf3a3fd8997e408
Author: DanInSpace104 <39777812+DanInSpace104@users.noreply.github.com>
Date:   Tue Aug 31 17:19:35 2021 +0500

    Dependencies for web setup

commit fb48b4b98e75bba2d2734f0d3e0f40982656c9bb
Author: DanInSpace104 <39777812+DanInSpace104@users.noreply.github.com>
Date:   Tue Aug 31 17:08:23 2021 +0500

    Installation on Fedora

    Added dependencies, which is needed for Fedora distributive.

commit ba5e6d79740b9366e04206f22b5742119fafd1ff
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Tue Aug 24 17:07:43 2021 +0200

    Update to egui 0.14.0

commit 6a6611d0b5a7a7cc96d9105dbe4e06657d09ec20
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon Aug 23 22:32:44 2021 +0200

    Add egui_template.js to sw.js for PWA

    Builds on https://github.com/emilk/egui_template/pull/15

commit d38861eae55b8d674b1a7276581155346343505c
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Fri Aug 20 14:37:33 2021 +0200

    Add libssl-dev to apt-get install

    Closes https://github.com/emilk/egui_template/issues/21

commit 0860f9f348d03f2abcb34615462dd8af18bffc04
Merge: 83a2dae da4fe81
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sun Aug 15 14:37:30 2021 +0200

    Merge pull request #15 from mankinskin/progressive-web-app

    Progressive Web App Support

commit da4fe814c2d4dff5955b7f951f4cbb2ddd124c1c
Author: Linus Behrbohm <linusbehrbohm@web.de>
Date:   Fri Jul 9 23:12:48 2021 +0200

    Add PWA files and service worker

commit 83a2dae19fa54506c0d2c69fe4d3566d896cd58d
Merge: c73f7e2 71afb6a
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Jul 29 23:11:34 2021 +0200

    Merge pull request #10 from imaitland/imaitland-patch-1

    Add `rustup update`

commit c73f7e2fe9aaffabc551388598754c20235caaf7
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Jul 29 23:10:18 2021 +0200

    Add all required dependencies to apt-get install list

    Closes https://github.com/emilk/egui_template/pull/17

commit 78cca3a50efd1762c7a87e802422bab54759bd32
Merge: 206078a 9766a9a
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Jul 29 23:08:22 2021 +0200

    Merge pull request #20 from emilk/fix-for-0.13

    Fix compilation with the persistence feature

commit 9766a9ae08532c2c9978082101d0c386b0464b09
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Jul 29 23:04:59 2021 +0200

    Fix compilation with persistence feature

commit 42ec177881aed23f0935187467031b5ca9d01309
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Jul 29 22:59:12 2021 +0200

    CI: check with --all-features

commit 206078aeb2fbde9059e7561dbd5c798964dfadb0
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Thu Jun 24 20:11:30 2021 +0200

    Update to egui/eframe 0.13.0

commit 71afb6af9b702d3848418ad15281f596b0b54e1e
Author: iain maitland <github@iainmaitland.com>
Date:   Wed Jun 16 09:54:57 2021 -0400

    Add `rustup update`

commit 573d7c48e85dd4c3e780f0fce538efe14e5d4611
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sat Jun 12 21:32:44 2021 +0200

    Document that you need latest stable rust

    Closes https://github.com/emilk/egui_template/issues/9

commit 443454be70c82f6662b351455f6a7311fdf577e3
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sat May 15 09:29:05 2021 +0200

    Simplify example slightly

commit c1aa867cfd5cd0f590f7dd8c162063514ea9cde2
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Sat May 15 09:27:46 2021 +0200

    Add serde(default) to TemplateApp

    Closes https://github.com/emilk/egui_template/issues/7

commit 7108ccab4918b522686a2985a4de27c2015c34f8
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon May 10 18:40:49 2021 +0200

    Update to egui/eframe 0.12.0

commit 341c11b9c7f24191f50dbfbd98f2488b1c387883
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Mon Apr 5 15:04:22 2021 +0200

    Update to egui/eframe 0.11.0

commit 96a7f26309d4c22a0a55edf560b1c9f8e7ecc7e6
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sun Feb 28 20:18:19 2021 +0100

    Update to egui/eframe 0.10.0

commit 20d399c83a2fb13e2fb1cab142cc491ef4a49a08
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sun Feb 21 12:58:48 2021 +0100

    Add docs about [patch.crates-io] and a shortcut to use latest master

commit c44a133d973d60af08d0dce2faf6a090c9d7e9c1
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sun Feb 21 12:57:34 2021 +0100

    Use basic-http-server instead of requiring python3

commit 962d81d4eb593342da6767a5a07aedd3d04a3c0f
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sun Feb 7 17:16:37 2021 +0100

    Update to eframe / egui 0.9.0

commit 26e1bb121f310ba820089fb42e1faeb8abe5de81
Merge: 572d39e 0249771
Author: Emil Ernerfeldt <emil.ernerfeldt@gmail.com>
Date:   Wed Feb 3 20:05:15 2021 +0100

    Merge pull request #3 from woelper/master

    Fix small typo

commit 02497718355f1ab18a085c315ea97a0fa6958da8
Author: Johann Woelper <woelper@gmail.com>
Date:   Wed Feb 3 09:46:08 2021 +0100

    Fix small typo

commit 572d39edcc8265109fc7eb77eb9896cb7485232b
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Wed Jan 20 17:28:51 2021 +0100

    Add note about required libraries on Linux

    Closes https://github.com/emilk/egui/issues/121

commit faebeab5c1e14440c5f37ce84c4e498616f5b7dd
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Wed Jan 20 17:13:35 2021 +0100

    Attempt to fix the CI

commit c4cf1632d09c8b694d012676717e522e9c4be040
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sun Jan 17 22:17:24 2021 +0100

    Disable test suite due to weird build issue

commit a4db3498f6c9eb811ae121391e1ab490f0b4f518
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sun Jan 17 15:36:33 2021 +0100

    Update to eframe / egui 0.8.0

commit 0492545a7a749c601bef8d2d4f9890bf16d0e248
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Mon Jan 4 16:10:12 2021 +0100

    Update to egui 0.7.0 with switch to eframe as the only dependency

commit e0cfa81c85a81d6939f890319fa5c5c547fddacb
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sat Dec 26 22:55:33 2020 +0100

    Update to Egui 0.6

commit fee20e6544854c14417579b659f272ca07411140
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sat Dec 26 19:30:40 2020 +0100

    Add github workflows CI

commit 8d86ae1715012e09501d5508db99d9e755037171
Author: Emil Ernerfeldt <emilernerfeldt@gmail.com>
Date:   Sat Dec 19 21:52:39 2020 +0100

    Initial commit

    Using the latest unpublished Egui.
    Will update to 0.6 once released.